### PR TITLE
Proposal to disable autoLock by default

### DIFF
--- a/spads/etc/spads.conf
+++ b/spads/etc/spads.conf
@@ -129,7 +129,7 @@ allowGhostMaps:0|1
 # Automatic features
 autoCallvote:1
 autoLockRunningBattle:0|1
-autoLock:on|off|advanced
+autoLock:off|on|advanced
 autoSpecExtraPlayers:1|0
 autoStart:on|off|advanced
 autoStop:gameOver|noOpponent|onlySpec|off


### PR DESCRIPTION
Only a proposal, so reject if you disagree, but I think autoLock should be "off" by default. Often people just want to spectate, but autoLock prevents clients from joining even only as spectators. teamSize is already used to control the number of players